### PR TITLE
Fix favorites to store full word entries in localStorage

### DIFF
--- a/menuLoader.js
+++ b/menuLoader.js
@@ -20,13 +20,39 @@ let slowMode = false;
 const LOCAL_STORAGE_KEY = "myDictionary";
 const FINISHED_LESSONS_KEY = "finishedLessons";
 
+function normalizeDictionaryEntry(entry) {
+  if (typeof entry === "string") {
+    return { word: entry, transcription: "", translation: "", example: "" };
+  }
+
+  if (!entry || typeof entry !== "object") {
+    return { word: "", transcription: "", translation: "", example: "" };
+  }
+
+  return {
+    word: (entry.word || "").toString().trim(),
+    transcription: (entry.transcription || "").toString(),
+    translation: (entry.translation || "").toString(),
+    example: (entry.example || "").toString()
+  };
+}
+
 function getMyDictionary() {
   const dict = localStorage.getItem(LOCAL_STORAGE_KEY);
-  return dict ? JSON.parse(dict) : [];
+  if (!dict) return [];
+
+  try {
+    const parsed = JSON.parse(dict);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map(normalizeDictionaryEntry).filter(entry => entry.word);
+  } catch {
+    return [];
+  }
 }
 
 function saveMyDictionary(dict) {
-  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(dict));
+  const normalized = (dict || []).map(normalizeDictionaryEntry).filter(entry => entry.word);
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(normalized));
 }
 
 function getFinishedLessons() {
@@ -43,18 +69,26 @@ function saveFinishedLesson(level, lessonKey) {
 
 // === Проверка словаря ===
 function isInDictionary(word) {
-  return getMyDictionary().includes(word);
+  const normalizedWord = normalizeDictionaryWord(word);
+  return getMyDictionary().some(entry => normalizeDictionaryWord(entry.word) === normalizedWord);
 }
 
-function toggleDictionary(word, button) {
-  let dict = getMyDictionary();
-  if (dict.includes(word)) {
-    dict = dict.filter(w => w !== word);
+function toggleDictionary(entryOrWord, button) {
+  const entry = normalizeDictionaryEntry(entryOrWord);
+  if (!entry.word) return;
+
+  const normalizedWord = normalizeDictionaryWord(entry.word);
+  const dict = getMyDictionary();
+  const existingIndex = dict.findIndex(item => normalizeDictionaryWord(item.word) === normalizedWord);
+
+  if (existingIndex >= 0) {
+    dict.splice(existingIndex, 1);
     button.textContent = "☆";
   } else {
-    dict.push(word);
+    dict.push(entry);
     button.textContent = "★";
   }
+
   saveMyDictionary(dict);
 }
 
@@ -254,8 +288,18 @@ function startDictionaryLesson() {
   const foundTransl = [];
   const foundExamples = [];
 
-  for (const savedWord of dict) {
-    const entry = findBestWordEntry(savedWord);
+  for (const savedEntry of dict) {
+    const normalizedSavedEntry = normalizeDictionaryEntry(savedEntry);
+
+    if (normalizedSavedEntry.translation || normalizedSavedEntry.transcription || normalizedSavedEntry.example) {
+      foundWords.push(normalizedSavedEntry.word);
+      foundTrans.push(normalizedSavedEntry.transcription);
+      foundTransl.push(normalizedSavedEntry.translation || "(перевод отсутствует)");
+      foundExamples.push(normalizedSavedEntry.example);
+      continue;
+    }
+
+    const entry = findBestWordEntry(normalizedSavedEntry.word);
 
     if (entry) {
       foundWords.push(entry.word);
@@ -265,9 +309,9 @@ function startDictionaryLesson() {
       continue;
     }
 
-    foundWords.push(savedWord);
+    foundWords.push(normalizedSavedEntry.word);
     foundTrans.push("");
-    foundTransl.push("(слово не найдено в уроках)");
+    foundTransl.push("(перевод отсутствует)");
     foundExamples.push("");
   }
 
@@ -365,8 +409,15 @@ function showNextCard() {
      <button id="addToDictionaryBtn" class="dictionary-btn">${isInDictionary(word) ? "★" : "☆"}</button>`;
   document.getElementById("cardExample").textContent = examples[currentIndex] || "";
 
+  const dictionaryEntry = {
+    word,
+    transcription: transcriptions[currentIndex],
+    translation: translations[currentIndex],
+    example: examples[currentIndex]
+  };
+
   document.getElementById("speakBtn").onclick = () => speakWord(word);
-  document.getElementById("addToDictionaryBtn").onclick = () => toggleDictionary(word, document.getElementById("addToDictionaryBtn"));
+  document.getElementById("addToDictionaryBtn").onclick = () => toggleDictionary(dictionaryEntry, document.getElementById("addToDictionaryBtn"));
 
   currentIndex++;
   updateProgress();


### PR DESCRIPTION
### Motivation
- Пользователи теряли переводы/транскрипции при добавлении слова в избранное, потому что в `localStorage` сохранялась только строка слова и затем происходил поиск в базе уроков как fallback. 
- Нужно, чтобы при нажатии "звёздочки" текущее содержимое карточки (`word`, `transcription`, `translation`, `example`) копировалось в отдельный пользовательский список и использовалось при показе словаря. 
- При этом требуется совместимость со старыми записями (строками) в `localStorage` и безопасное чтение/запись данных.

### Description
- Добавлена функция `normalizeDictionaryEntry` и изменён формат хранения: теперь элементы словаря нормализуются в объекты с полями `word`, `transcription`, `translation`, `example` в `menuLoader.js`.
- Обновлены функции `getMyDictionary` и `saveMyDictionary` для безопасного парсинга/нормализации и фильтрации пустых записей.
- Логика поиска/переключения избранного изменена: `isInDictionary` сравнивает по нормализованному слову, а `toggleDictionary` принимает либо строку, либо объект и сохраняет полный объект, оставляя сравнение и удаление по нормализованному `word`.
- `startDictionaryLesson` теперь отдаёт приоритет данным, сохранённым пользователем (если в записи есть перевод/транскрипция/пример), а не всегда подтягивает данные из базы; поиск в уроках используется как fallback для старых/пустых записей.
- В отображении карточки (фаза 3) кнопка добавления в словарь передаёт в `toggleDictionary` полный объект текущей карточки, чтобы копирование было «как есть».

### Testing
- Выполнена статическая проверка синтаксиса с `node --check menuLoader.js`, которая завершилась успешно. 
- Исправления закоммичены и подготовлены для PR; нет автотестов проекта, дополнительные интеграционные тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf6e3fcc1883249c99a45e32e9d990)